### PR TITLE
define LogConfig type for use in LaunchConfig

### DIFF
--- a/src/main/java/jenkins/plugins/rancher/entity/LaunchConfig.java
+++ b/src/main/java/jenkins/plugins/rancher/entity/LaunchConfig.java
@@ -18,6 +18,8 @@ public class LaunchConfig {
     private List<String> dataVolumes;
     private List<String> dataVolumesFrom;
 
+    private LogConfig logConfig;
+
     private String workingDir;
     private List<String> entryPoint;
     private List<String> command;
@@ -128,5 +130,13 @@ public class LaunchConfig {
 
     public void setPorts(List<String> ports) {
         this.ports = ports;
+    }
+
+    public LogConfig getLogConfig() {
+        return logConfig;
+    }
+
+    public void setLogConfig(LogConfig logConfig) {
+        this.logConfig = logConfig;
     }
 }

--- a/src/main/java/jenkins/plugins/rancher/entity/LogConfig.java
+++ b/src/main/java/jenkins/plugins/rancher/entity/LogConfig.java
@@ -1,0 +1,28 @@
+package jenkins.plugins.rancher.entity;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class LogConfig {
+    private String driver;
+    private Map<String, String> config = new HashMap<>();
+
+    public String getDriver() {
+        return driver;
+    }
+
+    public void setDriver(String driver) {
+        this.driver = driver;
+    }
+
+    public Map<String, String> getConfig() {
+        return config;
+    }
+
+    public void setConfig(Map<String, String> config) {
+        this.config = config;
+    }
+}


### PR DESCRIPTION
Defines a `LogConfig` type to allow (de)serialization of the `logConfig` property:
http://rancher.com/docs/rancher/v1.6/en/api/v2-beta/api-resources/launchConfig/

This preserves the log config while upgrading a service, previously this plugin would clobber log configs defined in rancher.