### PR TITLE
Adding support to use a more than one slash on the service name

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://7xq95u.com1.z0.glb.clouddn.com/gradle-2.14.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-bin.zip

--- a/src/main/java/jenkins/plugins/rancher/util/ServiceField.java
+++ b/src/main/java/jenkins/plugins/rancher/util/ServiceField.java
@@ -13,12 +13,12 @@ public class ServiceField {
             throw new AbortException("ServerName is Empty");
         }
 
-        String[] stackNameAndServiceName = service.split("/");
-        if (stackNameAndServiceName.length != 2) {
-            throw new AbortException("ServerName is Empty");
+        int firstSlashPosition = service.indexOf("/");
+        if (firstSlashPosition == -1) {
+            throw new AbortException("ServerName should be has StackName/ServiceName");
         }
-        this.stackName = stackNameAndServiceName[0].trim();
-        this.serviceName = stackNameAndServiceName[1].trim();
+        this.stackName = service.substring(0, firstSlashPosition);
+        this.serviceName = service.substring(firstSlashPosition + 1);
     }
 
     public String getStackName() {


### PR DESCRIPTION
I added support to use sidekick container, on rancher this kind of container has more one slash on the server name, I rewrite the validation to support more than one slash on the service name